### PR TITLE
Add GitHub Skills activity to the system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-"""
+""" 
 High School Management System API
 
 A super simple FastAPI application that allows students to view and sign up
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Resuelve
Closes #6

## 📋 Descripción
Agrega la actividad **GitHub Skills** que fue anunciada por el director en la asamblea escolar. Esta actividad estaba faltando en el sistema de inscripciones y los estudiantes no podían registrarse.

## ✨ Cambios Realizados
- ✅ Agregada la actividad "GitHub Skills" al diccionario de actividades
- ✅ Configurado con capacidad para 25 participantes
- ✅ Horario: Lunes y Miércoles, 3:30 PM - 5:00 PM
- ✅ Descripción incluye mención al programa de certificaciones de GitHub

## ⏱️ Urgencia
Este cambio es **urgente** ya que:
- Las inscripciones cierran a finales de esta semana
- Los estudiantes están esperando para inscribirse
- Fue anunciado oficialmente por el director

## 🎓 Beneficio
Esta actividad es parte del [programa de certificaciones de GitHub](https://resources.github.com/learn/certifications/) que ayudará a los estudiantes con sus solicitudes universitarias.

## ✅ Testing
La nueva actividad:
- Aparecerá en la lista de actividades disponibles
- Permitirá inscripciones hasta 25 estudiantes
- Funcionará con los endpoints existentes de signup/unregister